### PR TITLE
Obtaining and storing display id from rise-logger

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "iron-ajax": "PolymerElements/iron-ajax#^1.0.0",
     "polymer": "Polymer/polymer#^1.0.0",
-    "rise-logger": "https://github.com/Rise-Vision/rise-logger.git#1.0.0"
+    "rise-logger": "https://github.com/Rise-Vision/rise-logger.git#1.0.1"
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",

--- a/rise-financial-es6.js
+++ b/rise-financial-es6.js
@@ -51,7 +51,7 @@
     _onDisplayIdReceived( displayId ) {
       this._displayIdReceived = true;
 
-      if ( displayId && typeof displayId === "string" && displayId !== "" ) {
+      if ( displayId && typeof displayId === "string" ) {
         this._setDisplayId( displayId );
       }
 

--- a/rise-financial-es6.js
+++ b/rise-financial-es6.js
@@ -27,18 +27,49 @@
           value: () => {
             return [];
           }
+        },
+
+        /**
+         * The id of the display running this instance of the component.
+         */
+        displayId: {
+          type: String,
+          readOnly: true,
+          value: "preview"
         }
+
       };
+
+      this._displayIdReceived = false;
+      this._goPending = false;
     }
 
     _isValidUsage( usage ) {
       return usage === "standalone" || usage === "widget";
     }
 
+    _onDisplayIdReceived( displayId ) {
+      this._displayIdReceived = true;
+
+      if ( displayId && typeof displayId === "string" && displayId !== "" ) {
+        this._setDisplayId( displayId );
+      }
+
+      if ( this._goPending ) {
+        this._goPending = false;
+        this.go();
+      }
+    }
+
     ready() {
       let params = {
         event: "ready"
       };
+
+      // listen for logger display id received
+      this.$.logger.addEventListener( "rise-logger-display-id", ( e ) => {
+        this._onDisplayIdReceived( e.detail );
+      } );
 
       // only include usage_type if it's a valid usage value
       if ( this._isValidUsage( this.usage ) ) {
@@ -51,6 +82,17 @@
       this.$.logger.log( BQ_TABLE_NAME, params );
     }
 
+    /**
+     * Request to obtain the financial data
+     *
+     */
+    go() {
+      if ( this._displayIdReceived ) {
+        // TODO
+      } else {
+        this._goPending = true;
+      }
+    }
   }
 
   Polymer( RiseFinancial );

--- a/rise-financial.js
+++ b/rise-financial.js
@@ -65,7 +65,7 @@ var financialVersion = "1.0.0";
       value: function _onDisplayIdReceived(displayId) {
         this._displayIdReceived = true;
 
-        if (displayId && typeof displayId === "string" && displayId !== "") {
+        if (displayId && typeof displayId === "string") {
           this._setDisplayId(displayId);
         }
 

--- a/rise-financial.js
+++ b/rise-financial.js
@@ -39,8 +39,21 @@ var financialVersion = "1.0.0";
             value: function value() {
               return [];
             }
+          },
+
+          /**
+           * The id of the display running this instance of the component.
+           */
+          displayId: {
+            type: String,
+            readOnly: true,
+            value: "preview"
           }
+
         };
+
+        this._displayIdReceived = false;
+        this._goPending = false;
       }
     }, {
       key: "_isValidUsage",
@@ -48,11 +61,32 @@ var financialVersion = "1.0.0";
         return usage === "standalone" || usage === "widget";
       }
     }, {
+      key: "_onDisplayIdReceived",
+      value: function _onDisplayIdReceived(displayId) {
+        this._displayIdReceived = true;
+
+        if (displayId && typeof displayId === "string" && displayId !== "") {
+          this._setDisplayId(displayId);
+        }
+
+        if (this._goPending) {
+          this._goPending = false;
+          this.go();
+        }
+      }
+    }, {
       key: "ready",
       value: function ready() {
+        var _this = this;
+
         var params = {
           event: "ready"
         };
+
+        // listen for logger display id received
+        this.$.logger.addEventListener("rise-logger-display-id", function (e) {
+          _this._onDisplayIdReceived(e.detail);
+        });
 
         // only include usage_type if it's a valid usage value
         if (this._isValidUsage(this.usage)) {
@@ -63,6 +97,21 @@ var financialVersion = "1.0.0";
 
         // log usage
         this.$.logger.log(BQ_TABLE_NAME, params);
+      }
+
+      /**
+       * Request to obtain the financial data
+       *
+       */
+
+    }, {
+      key: "go",
+      value: function go() {
+        if (this._displayIdReceived) {
+          // TODO
+        } else {
+          this._goPending = true;
+        }
       }
     }]);
 

--- a/test/unit/rise-financial.html
+++ b/test/unit/rise-financial.html
@@ -96,7 +96,7 @@
       } );
 
       test( "should have display id maintain default value", () => {
-        financialRequest._onDisplayIdReceived( null );
+        financialRequest._onDisplayIdReceived( {} );
         assert.equal( "preview", financialRequest.displayId );
       } );
 

--- a/test/unit/rise-financial.html
+++ b/test/unit/rise-financial.html
@@ -65,6 +65,16 @@
         assert.include( JSON.stringify( logStub.args[ 0 ][ 1 ] ), "{\"event\":\"ready\",\"version\":" );
       } );
 
+      test( "should listen for 'rise-logger-display-id' event", () => {
+        let stub = sinon.stub( financialRequest, "_onDisplayIdReceived" );
+
+        financialRequest.ready();
+        financialRequest.$.logger._onDisplayIdResponse( null, { response: { displayId: "abc123" } } );
+        assert.isTrue( stub.calledWith( "abc123" ) );
+
+        stub.restore();
+      } );
+
       test( "should log usage and include 'usage_type'", () => {
         financialRequest.usage = "widget";
         financialRequest.ready();
@@ -72,6 +82,50 @@
         assert.include( JSON.stringify( logStub.args[ 0 ][ 1 ] ), "{\"event\":\"ready\",\"usage_type\":\"widget\",\"version\":" );
       } );
 
+    } );
+
+    suite( "_onDisplayIdReceived", () => {
+
+      teardown( () => {
+        financialRequest._setDisplayId( "preview" );
+      } );
+
+      test( "should set the display id to new value", () => {
+        financialRequest._onDisplayIdReceived( "abc123" );
+        assert.equal( "abc123", financialRequest.displayId );
+      } );
+
+      test( "should have display id maintain default value", () => {
+        financialRequest._onDisplayIdReceived( null );
+        assert.equal( "preview", financialRequest.displayId );
+      } );
+
+      test( "should call go() if go pending", () => {
+        let goStub = sinon.stub( financialRequest, "go" );
+
+        financialRequest._goPending = true;
+        financialRequest._onDisplayIdReceived( "abc123" );
+        assert.isFalse( financialRequest._goPending );
+        assert.isTrue( goStub.calledOnce );
+
+        goStub.restore();
+      } );
+
+    } );
+
+    suite( "go", () => {
+
+      teardown( function() {
+        financialRequest._setDisplayId( "preview" );
+        financialRequest._displayIdReceived = true;
+        financialRequest._goPending = false;
+      } );
+
+      test( "should flag that a go() is pending if display id has not been received", () => {
+        financialRequest._displayIdReceived = false;
+        financialRequest.go();
+        assert.isTrue( financialRequest._goPending );
+      } );
 
     } );
 


### PR DESCRIPTION
- Adding read-only attribute `displayId` which default value is "preview"
- Adding `go()` function and flagging if needs to execute after display id is received
- Using latest `rise-logger` and listening for "rise-logger-display-id" event to set `displayId` and execute `go()` if need be
- Added unit tests