### PR TITLE
Get historical data from financial server

### DIFF
--- a/config/prod.js
+++ b/config/prod.js
@@ -6,5 +6,6 @@ const config = {
   },
   financial: {
     realTimeURL: "http://contentfinancial2.appspot.com/data",
+    historicalURL: "http://contentfinancial2.appspot.com/data/historical",
   }
 };

--- a/config/prod.js
+++ b/config/prod.js
@@ -1,5 +1,10 @@
 /* exported config */
 const config = {
-  apiKey: "AIzaSyA8VXZwqhHx4qEtV5BcBNe41r7Ra0ZThfY",
-  databaseURL: "https://fir-b3915.firebaseio.com",
-}
+  firebase: {
+    apiKey: "AIzaSyA8VXZwqhHx4qEtV5BcBNe41r7Ra0ZThfY",
+    databaseURL: "https://fir-b3915.firebaseio.com",
+  },
+  financial: {
+    realTimeURL: "http://contentfinancial2.appspot.com/data",
+  }
+};

--- a/config/test.js
+++ b/config/test.js
@@ -1,5 +1,10 @@
 /* exported config */
 const config = {
-  apiKey: "AIzaSyA_tQUKBCYzj_VJwXpRNfna0-btAZe1b-w",
-  databaseURL: "https://fir-stage.firebaseio.com",
-}
+  firebase: {
+    apiKey: "AIzaSyA_tQUKBCYzj_VJwXpRNfna0-btAZe1b-w",
+    databaseURL: "https://fir-stage.firebaseio.com",
+  },
+  financial: {
+    realTimeURL: "http://contentfinancial2-test.appspot.com/data",
+  }
+};

--- a/config/test.js
+++ b/config/test.js
@@ -6,5 +6,6 @@ const config = {
   },
   financial: {
     realTimeURL: "http://contentfinancial2-test.appspot.com/data",
+    historicalURL: "http://contentfinancial2-test.appspot.com/data/historical",
   }
 };

--- a/rise-financial-es6.html
+++ b/rise-financial-es6.html
@@ -6,10 +6,10 @@
   <template>
     <byutv-jsonp
       auto
-      id="realTime"
+      id="financial"
       callback-value="callback"
-      on-response="_handleRealTimeData"
-      on-error="_handleRealTimeError"
+      on-response="_handleData"
+      on-error="_handleError"
       debounce-duration="300">
     </byutv-jsonp>
 

--- a/rise-financial-es6.js
+++ b/rise-financial-es6.js
@@ -112,19 +112,19 @@
       this.go();
     }
 
-    /***************************************** REAL-TIME ******************************************/
+    /***************************************** FINANCIAL ******************************************/
 
-    _getRealTimeParams( instruments, fields = [] ) {
+    _getParams( instruments, fields = [] ) {
       return Object.assign( {},
         {
           id: this.displayId,
           code: this._getSymbols( instruments ),
           tqx: "out:json;responseHandler:callback",
         },
-        fields.length > 0 ? { tq: this._getRealTimeQueryString( fields ) } : null );
+        fields.length > 0 ? { tq: this._getQueryString( fields ) } : null );
     }
 
-    _getRealTimeQueryString( fields = [] ) {
+    _getQueryString( fields = [] ) {
       if ( fields.length === 0 ) {
         return "";
       }
@@ -132,14 +132,14 @@
       return `select ${ fields.join( "," ) }`;
     }
 
-    _getRealTimeData( instruments, fields = [] ) {
-      const realTime = this.$.realTime;
+    _getData( instruments, fields = [] ) {
+      const financial = this.$.financial;
 
-      realTime.url = config.financial.realTimeURL;
-      realTime.params = this._getRealTimeParams( instruments, fields );
+      financial.url = config.financial.realTimeURL;
+      financial.params = this._getParams( instruments, fields );
     }
 
-    _handleRealTimeData( e, resp ) {
+    _handleData( e, resp ) {
       const response = {
         instruments: this._instruments,
       };
@@ -151,7 +151,7 @@
       this.fire( "rise-financial-response", response );
     }
 
-    _handleRealTimeError( e, resp ) {
+    _handleError( e, resp ) {
       this.fire( "rise-financial-error", resp );
     }
 
@@ -209,7 +209,7 @@
       }
 
       if ( this.type === "real-time" ) {
-        this._getRealTimeData( this._instruments, this.instrumentFields );
+        this._getData( this._instruments, this.instrumentFields );
       }
     }
   }

--- a/rise-financial-es6.js
+++ b/rise-financial-es6.js
@@ -32,6 +32,15 @@
         },
 
         /**
+         * Interval for which data should be retrieved.
+         * Valid values are: Day, Week, 1M, 3M, 6M, 1Y, 5Y.
+         */
+        duration: {
+          type: String,
+          value: "1M"
+        },
+
+        /**
          * The optional usage type for Rise Vision logging purposes. Options are "standalone" or "widget"
          */
         usage: {
@@ -80,6 +89,15 @@
 
     _isValidUsage( usage ) {
       return usage === "standalone" || usage === "widget";
+    }
+
+    _isValidDuration( duration, type ) {
+      if ( type.toLowerCase() === "historical" ) {
+        // Parameters passed to financial server are case sensitive.
+        return [ "Day", "Week", "1M", "3M", "6M", "1Y", "5Y" ].indexOf( duration ) !== -1;
+      } else {
+        return true;
+      }
     }
 
     _onDisplayIdReceived( displayId ) {

--- a/rise-financial-es6.js
+++ b/rise-financial-es6.js
@@ -114,10 +114,6 @@
 
     /***************************************** REAL-TIME ******************************************/
 
-    _getRealTimeUrl() {
-      return "http://contentfinancial2.appspot.com/data";
-    }
-
     _getRealTimeParams( instruments, fields = [] ) {
       return Object.assign( {},
         {
@@ -139,7 +135,7 @@
     _getRealTimeData( instruments, fields = [] ) {
       const realTime = this.$.realTime;
 
-      realTime.url = this._getRealTimeUrl();
+      realTime.url = config.financial.realTimeURL;
       realTime.params = this._getRealTimeParams( instruments, fields );
     }
 
@@ -173,7 +169,7 @@
       };
 
       if ( !this._firebaseApp ) {
-        this._firebaseApp = firebase.initializeApp( config );
+        this._firebaseApp = firebase.initializeApp( config.firebase );
       }
 
       // listen for logger display id received

--- a/test/index.html
+++ b/test/index.html
@@ -12,7 +12,8 @@
 <script>
   /* global WCT */
   WCT.loadSuites( [
-    "unit/rise-financial.html"
+    "unit/rise-financial-historical.html",
+    "unit/rise-financial.html",
   ] );
 </script>
 </body>

--- a/test/unit/rise-financial-historical.html
+++ b/test/unit/rise-financial-historical.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+  <title>rise-financial</title>
+
+  <script src="../../bower_components/webcomponentsjs/webcomponents.min.js"></script>
+  <script src="../../bower_components/web-component-tester/browser.js"></script>
+
+  <link rel="import" href="../../rise-financial-es6.html">
+
+  <script src="../mocks/firebase.js"></script>
+
+</head>
+<body>
+
+<rise-financial id="request" financial-list="Stocks" instrument-fields='["closePrice", "percentChange"]' type="historical"></rise-financial>
+
+<script src="../data/real-time.js"></script>
+
+<script>
+
+  /* global sinon, suite, test, assert */
+
+  const financialRequest = document.querySelector( "#request" );
+
+  // mock logger getting display id and force handler of RC not running
+  sinon.stub( financialRequest.$.logger.$.displayId, "generateRequest", () => {
+    financialRequest.$.logger._onDisplayIdError();
+  } );
+
+  suite( "rise-financial", () => {
+
+    suite( "_isValidDuration", () => {
+
+      test( "should return true if retrieving historical data for a valid duration", () => {
+        assert.isTrue( financialRequest._isValidDuration( "Week", "historical" ) );
+      } );
+
+      test( "should return false if retrieving historical data for an invalid duration", () => {
+        assert.isFalse( financialRequest._isValidDuration( "week", "historical" ) );
+      } );
+
+      test( "should return true if not retrieving historical data", () => {
+        assert.isTrue( financialRequest._isValidDuration( "week", "real-time" ) );
+      } );
+
+    } );
+
+  } );
+</script>
+</body>
+</html>

--- a/test/unit/rise-financial-historical.html
+++ b/test/unit/rise-financial-historical.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-  <title>rise-financial</title>
+  <title>rise-financial - Historical</title>
 
   <script src="../../bower_components/webcomponentsjs/webcomponents.min.js"></script>
   <script src="../../bower_components/web-component-tester/browser.js"></script>
@@ -21,7 +21,7 @@
 
 <script>
 
-  /* global sinon, suite, test, assert */
+  /* global sinon, suite, test, assert, setup */
 
   const financialRequest = document.querySelector( "#request" );
 
@@ -30,7 +30,7 @@
     financialRequest.$.logger._onDisplayIdError();
   } );
 
-  suite( "rise-financial", () => {
+  suite( "rise-financial - Historical", () => {
 
     suite( "_isValidDuration", () => {
 
@@ -44,6 +44,55 @@
 
       test( "should return true if not retrieving historical data", () => {
         assert.isTrue( financialRequest._isValidDuration( "week", "real-time" ) );
+      } );
+
+    } );
+
+    suite( "_getData", () => {
+
+      const financial = document.getElementById( "financial" ),
+        instrument = {
+          "AA?N": {
+            category: "Stocks",
+            index: 0,
+            name: "Alcoa",
+            symbol: "AA.N",
+          }
+        },
+        props = {
+          type: "historical",
+          duration: "1M",
+        };
+
+      setup( () => {
+        financial.url = "";
+        financial.params = {};
+      } );
+
+      test( "should not set attributes of JSONP component for an invalid duration", () => {
+        financialRequest._getData( { type: "historical", duration: "invalid" }, instrument, [] );
+
+        assert.equal( financial.url, "" );
+        assert.deepEqual( financial.params, {} );
+      } );
+
+      test( "should set 'url' attribute of JSONP component", () => {
+        financialRequest._getData( props, instrument, [] );
+
+        assert.equal( financial.url, "http://contentfinancial2-test.appspot.com/data/historical" );
+      } );
+
+      test( "should set 'params' attribute of JSONP component", () => {
+        const expected = {
+          id: "preview",
+          code: "AA.N",
+          tqx: "out:json;responseHandler:callback",
+          kind: "1M",
+        };
+
+        financialRequest._getData( props, instrument, [] );
+
+        assert.deepEqual( financial.params, expected );
       } );
 
     } );

--- a/test/unit/rise-financial.html
+++ b/test/unit/rise-financial.html
@@ -69,6 +69,10 @@
         assert.equal( financialRequest.type, "real-time" );
       } );
 
+      test( "should set default duration property", () => {
+        assert.equal( financialRequest.duration, "1M" );
+      } );
+
     } );
 
     suite( "_isValidType", () => {

--- a/test/unit/rise-financial.html
+++ b/test/unit/rise-financial.html
@@ -170,7 +170,7 @@
 
     } );
 
-    suite( "_getRealTimeParams", () => {
+    suite( "_getParams", () => {
 
       test( "should return query parameters object", () => {
         const expected = {
@@ -180,7 +180,7 @@
           tqx: "out:json;responseHandler:callback",
         };
 
-        assert.deepEqual( financialRequest._getRealTimeParams( instrument, fields ), expected );
+        assert.deepEqual( financialRequest._getParams( instrument, fields ), expected );
       } );
 
       test( "should return query parameters object with no 'tq' property", () => {
@@ -190,66 +190,69 @@
           tqx: "out:json;responseHandler:callback",
         };
 
-        assert.deepEqual( financialRequest._getRealTimeParams( instrument ), expected );
+        assert.deepEqual( financialRequest._getParams( instrument ), expected );
       } );
 
     } );
 
-    suite( "_getRealTimeQueryString", () => {
+    suite( "_getQueryString", () => {
 
       test( "should return query string for fetching a specific set of fields", () => {
         const expected = "select lastPrice,netChange";
 
-        assert.equal( financialRequest._getRealTimeQueryString( fields ), expected );
+        assert.equal( financialRequest._getQueryString( fields ), expected );
       } );
 
       test( "should return empty string if no parameter specified", () => {
-        assert.equal( financialRequest._getRealTimeQueryString(), "" );
+        assert.equal( financialRequest._getQueryString(), "" );
       } );
 
     } );
 
-    suite( "_getRealTimeData", () => {
+    suite( "_getData", () => {
+
+      const financial = document.getElementById( "financial" );
+
+      setup( () => {
+        financial.url = "";
+        financial.params = {};
+      } );
 
       test( "should set 'url' attribute of JSONP component", () => {
-        const realTime = document.getElementById( "realTime" );
+        financialRequest._getData( instruments );
 
-        financialRequest._getRealTimeData( instruments );
-
-        assert.equal( realTime.url, "http://contentfinancial2-test.appspot.com/data" );
+        assert.equal( financial.url, "http://contentfinancial2-test.appspot.com/data" );
       } );
 
       test( "should set 'params' attribute of JSONP component for single instrument", () => {
-        const realTime = document.getElementById( "realTime" ),
-          expected = {
-            id: "preview",
-            code: "AA.N",
-            tq: "select lastPrice,netChange",
-            tqx: "out:json;responseHandler:callback",
-          };
+        const expected = {
+          id: "preview",
+          code: "AA.N",
+          tq: "select lastPrice,netChange",
+          tqx: "out:json;responseHandler:callback",
+        };
 
-        financialRequest._getRealTimeData( instrument, fields );
+        financialRequest._getData( instrument, fields );
 
-        assert.deepEqual( realTime.params, expected );
+        assert.deepEqual( financial.params, expected );
       } );
 
       test( "should set 'params' attribute of JSONP component for multiple instruments", () => {
-        const realTime = document.getElementById( "realTime" ),
-          expected = {
-            id: "preview",
-            code: "AA.N|.DJI",
-            tq: "select lastPrice,netChange",
-            tqx: "out:json;responseHandler:callback",
-          };
+        const expected = {
+          id: "preview",
+          code: "AA.N|.DJI",
+          tq: "select lastPrice,netChange",
+          tqx: "out:json;responseHandler:callback",
+        };
 
-        financialRequest._getRealTimeData( instruments, fields );
+        financialRequest._getData( instruments, fields );
 
-        assert.deepEqual( realTime.params, expected );
+        assert.deepEqual( financial.params, expected );
       } );
 
     } );
 
-    suite( "_handleRealTimeData", () => {
+    suite( "_handleData", () => {
       const e = { stopPropagation: () => {} };
 
       setup( () => {
@@ -272,7 +275,7 @@
         };
 
         financialRequest.addEventListener( "rise-financial-response", listener );
-        financialRequest._handleRealTimeData( e, realTimeData );
+        financialRequest._handleData( e, realTimeData );
       } );
 
       test( "should pass only instruments in 'rise-financial-response' event", ( done ) => {
@@ -286,12 +289,12 @@
         };
 
         financialRequest.addEventListener( "rise-financial-response", listener );
-        financialRequest._handleRealTimeData( e, {} );
+        financialRequest._handleData( e, {} );
       } );
 
     } );
 
-    suite( "_handleRealTimeError", () => {
+    suite( "_handleError", () => {
 
       test( "should fire rise-financial-error", ( done ) => {
         const resp =
@@ -309,7 +312,7 @@
           };
 
         financialRequest.addEventListener( "rise-financial-error", listener );
-        financialRequest._handleRealTimeError( {}, resp );
+        financialRequest._handleError( {}, resp );
       } );
 
     } );
@@ -392,8 +395,8 @@
         assert.isTrue( financialRequest._goPending );
       } );
 
-      test( "should call _getRealTimeData() if display ID and instruments have been received", () => {
-        const spy = sinon.spy( financialRequest, "_getRealTimeData" );
+      test( "should call _getData() if display ID and instruments have been received", () => {
+        const spy = sinon.spy( financialRequest, "_getData" );
 
         financialRequest._displayIdReceived = true;
         financialRequest._instrumentsReceived = true;

--- a/test/unit/rise-financial.html
+++ b/test/unit/rise-financial.html
@@ -194,7 +194,7 @@
           tqx: "out:json;responseHandler:callback",
         };
 
-        assert.deepEqual( financialRequest._getParams( instrument ), expected );
+        assert.deepEqual( financialRequest._getParams( instrument, [] ), expected );
       } );
 
     } );
@@ -208,22 +208,33 @@
       } );
 
       test( "should return empty string if no parameter specified", () => {
-        assert.equal( financialRequest._getQueryString(), "" );
+        assert.equal( financialRequest._getQueryString( [] ), "" );
       } );
 
     } );
 
     suite( "_getData", () => {
 
-      const financial = document.getElementById( "financial" );
+      const financial = document.getElementById( "financial" ),
+        props = {
+          type: "real-time",
+          duration: "1M",
+        };
 
       setup( () => {
         financial.url = "";
         financial.params = {};
       } );
 
+      test( "should not set attributes of JSONP component for an invalid type", () => {
+        financialRequest._getData( { type: "invalid", duration: "1M" }, instruments, [] );
+
+        assert.equal( financial.url, "" );
+        assert.deepEqual( financial.params, {} );
+      } );
+
       test( "should set 'url' attribute of JSONP component", () => {
-        financialRequest._getData( instruments );
+        financialRequest._getData( props, instruments, [] );
 
         assert.equal( financial.url, "http://contentfinancial2-test.appspot.com/data" );
       } );
@@ -236,7 +247,7 @@
           tqx: "out:json;responseHandler:callback",
         };
 
-        financialRequest._getData( instrument, fields );
+        financialRequest._getData( props, instrument, fields );
 
         assert.deepEqual( financial.params, expected );
       } );
@@ -249,7 +260,7 @@
           tqx: "out:json;responseHandler:callback",
         };
 
-        financialRequest._getData( instruments, fields );
+        financialRequest._getData( props, instruments, fields );
 
         assert.deepEqual( financial.params, expected );
       } );

--- a/test/unit/rise-financial.html
+++ b/test/unit/rise-financial.html
@@ -170,14 +170,6 @@
 
     } );
 
-    suite( "_getRealTimeUrl", () => {
-
-      test( "should return URL for Financial server", () => {
-        assert.equal( financialRequest._getRealTimeUrl(), "http://contentfinancial2.appspot.com/data" );
-      } );
-
-    } );
-
     suite( "_getRealTimeParams", () => {
 
       test( "should return query parameters object", () => {
@@ -224,7 +216,7 @@
 
         financialRequest._getRealTimeData( instruments );
 
-        assert.equal( realTime.url, "http://contentfinancial2.appspot.com/data" );
+        assert.equal( realTime.url, "http://contentfinancial2-test.appspot.com/data" );
       } );
 
       test( "should set 'params' attribute of JSONP component for single instrument", () => {


### PR DESCRIPTION
Adds a new `duration` property to the component to specify the interval for which data should be retrieved.

Fires `rise-financial-response` and returns the following data:

![historical-data](https://cloud.githubusercontent.com/assets/1190420/21229289/1ca59044-c2af-11e6-89e1-e83277d3e0d7.png)

Fires `rise-financial-error` if there's a problem retrieving data from the financial server.