### PR TITLE
Log an error when request to financial server fails

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
     "byutv-jsonp": "^1.3.0",
     "iron-ajax": "PolymerElements/iron-ajax#^1.0.0",
     "polymer": "Polymer/polymer#^1.0.0",
-    "rise-logger": "https://github.com/Rise-Vision/rise-logger.git#1.0.1"
+    "rise-logger": "https://github.com/Rise-Vision/rise-logger.git#1.0.2"
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",

--- a/rise-financial-es6.js
+++ b/rise-financial-es6.js
@@ -118,6 +118,17 @@
       this.go();
     }
 
+    _log( params ) {
+      // only include usage_type if it's a valid usage value
+      if ( this._isValidUsage( this.usage ) ) {
+        params.usage_type = this.usage;
+      }
+
+      params.version = financialVersion;
+
+      this.$.logger.log( BQ_TABLE_NAME, params );
+    }
+
     /***************************************** FIREBASE *******************************************/
 
     _getInstruments() {
@@ -190,6 +201,14 @@
     }
 
     _handleError( e, resp ) {
+      // error response provides no request or error objects, use instruments to provide some detail instead
+      let params = {
+        event: "error",
+        event_details: `Instrument List: ${ JSON.stringify( this._instruments ) }`
+      };
+
+      this._log( params );
+
       this.fire( "rise-financial-error", resp );
       this._startTimer();
     }
@@ -216,15 +235,7 @@
         this._onDisplayIdReceived( e.detail );
       } );
 
-      // only include usage_type if it's a valid usage value
-      if ( this._isValidUsage( this.usage ) ) {
-        params.usage_type = this.usage;
-      }
-
-      params.version = financialVersion;
-
-      // log usage
-      this.$.logger.log( BQ_TABLE_NAME, params );
+      this._log( params );
     }
 
     attached() {

--- a/test/unit/rise-financial.html
+++ b/test/unit/rise-financial.html
@@ -147,6 +147,41 @@
 
     } );
 
+    suite( "_log", () => {
+      let logStub;
+
+      setup( () => {
+        logStub = sinon.stub( financialRequest.$.logger, "log" );
+      } );
+
+      teardown( () => {
+        logStub.restore();
+        financialRequest.usage = "";
+      } );
+
+      test( "should include version", () => {
+        financialRequest._log( {} );
+        assert.equal( logStub.args[ 0 ][ 0 ], "component_financial_events" );
+        assert.include( JSON.stringify( logStub.args[ 0 ][ 1 ] ), "{\"version\":" );
+      } );
+
+      test( "should include 'usage_type' if valid", () => {
+        financialRequest.usage = "widget";
+        financialRequest._log( {} );
+        assert.equal( logStub.args[ 0 ][ 0 ], "component_financial_events" );
+        assert.include( JSON.stringify( logStub.args[ 0 ][ 1 ] ), "{\"usage_type\":\"widget\"" );
+      } );
+
+      test( "should include any params provided", () => {
+        financialRequest._log( {
+          event: "error",
+          event_details: "test"
+        } );
+        assert.equal( logStub.args[ 0 ][ 0 ], "component_financial_events" );
+        assert.include( JSON.stringify( logStub.args[ 0 ][ 1 ] ), "{\"event\":\"error\",\"event_details\":\"test\"" );
+      } );
+    } );
+
     suite( "_getInstruments", () => {
       let spy;
 
@@ -335,6 +370,15 @@
     } );
 
     suite( "_handleError", () => {
+      let logStub;
+
+      setup( () => {
+        logStub = sinon.stub( financialRequest, "_log" );
+      } );
+
+      teardown( () => {
+        logStub.restore();
+      } );
 
       test( "should fire rise-financial-error", ( done ) => {
         const resp =
@@ -355,6 +399,23 @@
         financialRequest._handleError( {}, resp );
       } );
 
+      test( "should call _log() with correct params", () => {
+        const resp =
+          {
+            "request": {
+              "status": 404,
+              "statusText": "An error occurred"
+            }
+          };
+
+        financialRequest._handleError( {}, resp );
+
+        assert.isTrue( logStub.calledWith( {
+          event: "error",
+          event_details: `Instrument List: ${ JSON.stringify( financialRequest._instruments ) }`
+        } ) );
+      } );
+
     } );
 
     suite( "_getSymbols", () => {
@@ -373,12 +434,11 @@
       let logStub;
 
       setup( () => {
-        logStub = sinon.stub( financialRequest.$.logger, "log" );
+        logStub = sinon.stub( financialRequest, "_log" );
       } );
 
       teardown( () => {
         logStub.restore();
-        financialRequest.usage = "";
       } );
 
       test( "should initialize Firebase", () => {
@@ -386,10 +446,12 @@
         assert.isObject( financialRequest._firebaseApp );
       } );
 
-      test( "should log usage", () => {
+      test( "should call _log() with correct params", () => {
         financialRequest.ready();
-        assert.equal( logStub.args[ 0 ][ 0 ], "component_financial_events" );
-        assert.include( JSON.stringify( logStub.args[ 0 ][ 1 ] ), "{\"event\":\"ready\",\"version\":" );
+
+        assert.isTrue( logStub.calledWith( {
+          event: "ready"
+        } ) );
       } );
 
       test( "should listen for 'rise-logger-display-id' event", () => {
@@ -401,14 +463,6 @@
 
         stub.restore();
       } );
-
-      test( "should log usage and include 'usage_type'", () => {
-        financialRequest.usage = "widget";
-        financialRequest.ready();
-        assert.equal( logStub.args[ 0 ][ 0 ], "component_financial_events" );
-        assert.include( JSON.stringify( logStub.args[ 0 ][ 1 ] ), "{\"event\":\"ready\",\"usage_type\":\"widget\",\"version\":" );
-      } );
-
     } );
 
     suite( "go", () => {


### PR DESCRIPTION
- Using latest version of `rise-logger`
- Log an error and provide instrument list as event details
- Consolidated common logging functionality into `_log` function
- Unit tests added and revised