### PR TITLE
Caching data to conditionally handle error and refresh 

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ Next, construct your HTML page. You should include `webcomponents-lite.min.js` b
         financial.addEventListener( "rise-financial-error", ( e ) => {
           console.log( e.detail );
         } );
+        
+        financial.addEventListener( "rise-financial-no-network", ( e ) => {
+          console.log( "No cached data available and no network" );
+        } );
 
         // Request the financial data.
         financial.go();

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ Next, construct your HTML page. You should include `webcomponents-lite.min.js` b
           console.log( e.detail );
         } );
         
-        financial.addEventListener( "rise-financial-no-network", ( e ) => {
-          console.log( "No cached data available and no network" );
+        financial.addEventListener( "rise-financial-no-data", ( e ) => {
+          console.log( "No data available" );
         } );
 
         // Request the financial data.

--- a/bower.json
+++ b/bower.json
@@ -22,10 +22,14 @@
     "byutv-jsonp": "^1.3.0",
     "iron-ajax": "PolymerElements/iron-ajax#^1.0.0",
     "polymer": "Polymer/polymer#^1.0.0",
+    "rise-data": "https://github.com/Rise-Vision/rise-data.git#1.1.0",
     "rise-logger": "https://github.com/Rise-Vision/rise-logger.git#1.0.2"
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
     "web-component-tester": "*"
+  },
+  "resolutions": {
+    "rise-logger": "1.0.2"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-financial",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "authors": [
     "Rise Vision"
   ],

--- a/config/prod.js
+++ b/config/prod.js
@@ -1,5 +1,8 @@
 /* exported config */
 const config = {
+  cache: {
+    baseKeyName: "risefinancial"
+  },
   firebase: {
     apiKey: "AIzaSyA8VXZwqhHx4qEtV5BcBNe41r7Ra0ZThfY",
     databaseURL: "https://fir-b3915.firebaseio.com",

--- a/config/test.js
+++ b/config/test.js
@@ -1,5 +1,8 @@
 /* exported config */
 const config = {
+  cache: {
+    baseKeyName: "risefinancial"
+  },
   firebase: {
     apiKey: "AIzaSyA_tQUKBCYzj_VJwXpRNfna0-btAZe1b-w",
     databaseURL: "https://fir-stage.firebaseio.com",

--- a/demo/index.html
+++ b/demo/index.html
@@ -22,6 +22,10 @@
       console.log( e.detail );
     } );
 
+    financial.addEventListener( "rise-financial-no-network", () => {
+      console.log( "No cached data available and no network" );
+    } );
+
     financial.go();
   </script>
 </body>

--- a/demo/index.html
+++ b/demo/index.html
@@ -22,7 +22,7 @@
       console.log( e.detail );
     } );
 
-    financial.addEventListener( "rise-financial-no-network", () => {
+    financial.addEventListener( "rise-financial-no-data", () => {
       console.log( "No cached data available and no network" );
     } );
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-financial",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Rise Vision web component for managing financial data",
   "scripts": {
     "test": "gulp test",

--- a/rise-financial-es6.html
+++ b/rise-financial-es6.html
@@ -1,6 +1,7 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../byutv-jsonp/byutv-jsonp.html" />
 <link rel="import" href="../rise-logger/rise-logger.html">
+<link rel="import" href="../rise-data/rise-data.html">
 
 <dom-module id="rise-financial">
   <template>
@@ -14,6 +15,7 @@
     </byutv-jsonp>
 
     <rise-logger id="logger"></rise-logger>
+    <rise-data id="data" endpoint="financial"></rise-data>
 
     <content></content>
   </template>

--- a/rise-financial-es6.js
+++ b/rise-financial-es6.js
@@ -323,20 +323,26 @@
           this._instruments,
           this.instrumentFields
         );
-      } else {
-        // get cached data (if available)
-        this.$.data.getItem( this._getDataCacheKey(), ( cachedData ) => {
-          if ( this._refreshPending || !cachedData ) {
-            // refresh timer completed or there is no cached data available
-            this._refreshPending = false;
-            // execute a request
-            this.$.financial.generateRequest();
-          } else {
-            // provide cached data for the response
-            this.fire( "rise-financial-response", cachedData );
-          }
-        } );
+
+        return;
       }
+
+      // execute new request when a refresh is pending
+      if ( this._refreshPending ) {
+        this._refreshPending = false;
+        this.$.financial.generateRequest();
+
+        return;
+      }
+
+      // provide cached data (if available)
+      this.$.data.getItem( this._getDataCacheKey(), ( cachedData ) => {
+        if ( !cachedData ) {
+          this.$.financial.generateRequest();
+        } else {
+          this.fire( "rise-financial-response", cachedData );
+        }
+      } );
     }
   }
 

--- a/rise-financial-es6.js
+++ b/rise-financial-es6.js
@@ -222,7 +222,7 @@
         if ( cachedData ) {
           this.fire( "rise-financial-response", cachedData );
         } else {
-          this.fire( "rise-financial-no-network" );
+          this.fire( "rise-financial-no-data" );
         }
       } );
 

--- a/rise-financial-es6.js
+++ b/rise-financial-es6.js
@@ -223,6 +223,8 @@
         response.data = resp.table;
       }
 
+      this.$.data.saveItem( this._getDataCacheKey(), response );
+
       this.fire( "rise-financial-response", response );
       this._startTimer();
     }

--- a/rise-financial-es6.js
+++ b/rise-financial-es6.js
@@ -140,6 +140,10 @@
       this.$.logger.log( BQ_TABLE_NAME, params );
     }
 
+    _getDataCacheKey() {
+      return `${config.cache.baseKeyName}_${this.type}_${this.displayId}_${this.financialList}`;
+    }
+
     /***************************************** FIREBASE *******************************************/
 
     _getInstruments() {

--- a/rise-financial-es6.js
+++ b/rise-financial-es6.js
@@ -214,6 +214,18 @@
       financial.params = params;
     }
 
+    _handleNoNetwork() {
+      this.$.data.getItem( this._getDataCacheKey(), ( cachedData ) => {
+        if ( cachedData ) {
+          this.fire( "rise-financial-response", cachedData );
+        } else {
+          this.fire( "rise-financial-no-network" );
+        }
+      } );
+
+      this._startTimer();
+    }
+
     _handleData( e, resp ) {
       const response = {
         instruments: this._instruments,
@@ -236,10 +248,18 @@
         event_details: `Instrument List: ${ JSON.stringify( this._instruments ) }`
       };
 
-      this._log( params );
+      // check for no network
+      if ( this.$.financial.lastRequest && this.$.financial.lastRequest.status === 0 ) {
+        this._handleNoNetwork();
+      } else {
+        this._log( params );
 
-      this.fire( "rise-financial-error", resp );
-      this._startTimer();
+        // delete cached data
+        this.$.data.deleteItem( this._getDataCacheKey() );
+
+        this.fire( "rise-financial-error", resp );
+        this._startTimer();
+      }
     }
 
     _getSymbols( instruments ) {

--- a/rise-financial.html
+++ b/rise-financial.html
@@ -1,6 +1,7 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../byutv-jsonp/byutv-jsonp.html" />
 <link rel="import" href="../rise-logger/rise-logger.html">
+<link rel="import" href="../rise-data/rise-data.html">
 
 <dom-module id="rise-financial">
   <template>
@@ -14,6 +15,7 @@
     </byutv-jsonp>
 
     <rise-logger id="logger"></rise-logger>
+    <rise-data id="data" endpoint="financial"></rise-data>
 
     <content></content>
   </template>

--- a/rise-financial.js
+++ b/rise-financial.js
@@ -19,7 +19,7 @@ var config = {
   }
 };
 
-var financialVersion = "1.0.1";
+var financialVersion = "1.1.0";
 (function financial() {
   /* global Polymer, financialVersion, firebase, config */
 

--- a/rise-financial.js
+++ b/rise-financial.js
@@ -377,20 +377,26 @@ var financialVersion = "1.1.0";
             type: this.type,
             duration: this.duration
           }, this._instruments, this.instrumentFields);
-        } else {
-          // get cached data (if available)
-          this.$.data.getItem(this._getDataCacheKey(), function (cachedData) {
-            if (_this4._refreshPending || !cachedData) {
-              // refresh timer completed or there is no cached data available
-              _this4._refreshPending = false;
-              // execute a request
-              _this4.$.financial.generateRequest();
-            } else {
-              // provide cached data for the response
-              _this4.fire("rise-financial-response", cachedData);
-            }
-          });
+
+          return;
         }
+
+        // execute new request when a refresh is pending
+        if (this._refreshPending) {
+          this._refreshPending = false;
+          this.$.financial.generateRequest();
+
+          return;
+        }
+
+        // provide cached data (if available)
+        this.$.data.getItem(this._getDataCacheKey(), function (cachedData) {
+          if (!cachedData) {
+            _this4.$.financial.generateRequest();
+          } else {
+            _this4.fire("rise-financial-response", cachedData);
+          }
+        });
       }
     }]);
 

--- a/rise-financial.js
+++ b/rise-financial.js
@@ -102,6 +102,7 @@ var financialVersion = "1.0.1";
         };
 
         this._displayIdReceived = false;
+        this._dataPingReceived = false;
         this._instrumentsReceived = false;
         this._goPending = false;
         this._instruments = {};
@@ -139,6 +140,15 @@ var financialVersion = "1.0.1";
         }, 60000);
       }
     }, {
+      key: "_onDataPingReceived",
+      value: function _onDataPingReceived() {
+        this._dataPingReceived = true;
+
+        if (this._goPending) {
+          this.go();
+        }
+      }
+    }, {
       key: "_onDisplayIdReceived",
       value: function _onDisplayIdReceived(displayId) {
         this._displayIdReceived = true;
@@ -147,7 +157,9 @@ var financialVersion = "1.0.1";
           this._setDisplayId(displayId);
         }
 
-        this.go();
+        if (this._goPending) {
+          this.go();
+        }
       }
     }, {
       key: "_log",
@@ -183,7 +195,10 @@ var financialVersion = "1.0.1";
         this._instruments = instruments ? instruments : {};
         this._saveInstruments(this._instruments);
         this._instrumentsReceived = true;
-        this.go();
+
+        if (this._goPending) {
+          this.go();
+        }
       }
     }, {
       key: "_saveInstruments",
@@ -284,6 +299,11 @@ var financialVersion = "1.0.1";
           this._firebaseApp = firebase.initializeApp(config.firebase);
         }
 
+        // listen for data ping received
+        this.$.data.addEventListener("rise-data-ping-received", function (e) {
+          _this2._onDataPingReceived(e.detail);
+        });
+
         // listen for logger display id received
         this.$.logger.addEventListener("rise-logger-display-id", function (e) {
           _this2._onDisplayIdReceived(e.detail);
@@ -304,7 +324,7 @@ var financialVersion = "1.0.1";
     }, {
       key: "go",
       value: function go() {
-        if (!this._displayIdReceived || !this._instrumentsReceived) {
+        if (!this._displayIdReceived || !this._instrumentsReceived || !this._dataPingReceived) {
           this._goPending = true;
           return;
         }

--- a/rise-financial.js
+++ b/rise-financial.js
@@ -6,6 +6,9 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 
 /* exported config */
 var config = {
+  cache: {
+    baseKeyName: "risefinancial"
+  },
   firebase: {
     apiKey: "AIzaSyA8VXZwqhHx4qEtV5BcBNe41r7Ra0ZThfY",
     databaseURL: "https://fir-b3915.firebaseio.com"
@@ -172,6 +175,11 @@ var financialVersion = "1.0.1";
         params.version = financialVersion;
 
         this.$.logger.log(BQ_TABLE_NAME, params);
+      }
+    }, {
+      key: "_getDataCacheKey",
+      value: function _getDataCacheKey() {
+        return config.cache.baseKeyName + "_" + this.type + "_" + this.displayId + "_" + this.financialList;
       }
 
       /***************************************** FIREBASE *******************************************/

--- a/rise-financial.js
+++ b/rise-financial.js
@@ -269,7 +269,7 @@ var financialVersion = "1.1.0";
           if (cachedData) {
             _this2.fire("rise-financial-response", cachedData);
           } else {
-            _this2.fire("rise-financial-no-network");
+            _this2.fire("rise-financial-no-data");
           }
         });
 

--- a/rise-financial.js
+++ b/rise-financial.js
@@ -258,6 +258,21 @@ var financialVersion = "1.0.1";
         financial.params = params;
       }
     }, {
+      key: "_handleNoNetwork",
+      value: function _handleNoNetwork() {
+        var _this2 = this;
+
+        this.$.data.getItem(this._getDataCacheKey(), function (cachedData) {
+          if (cachedData) {
+            _this2.fire("rise-financial-response", cachedData);
+          } else {
+            _this2.fire("rise-financial-no-network");
+          }
+        });
+
+        this._startTimer();
+      }
+    }, {
       key: "_handleData",
       value: function _handleData(e, resp) {
         var response = {
@@ -282,10 +297,18 @@ var financialVersion = "1.0.1";
           event_details: "Instrument List: " + JSON.stringify(this._instruments)
         };
 
-        this._log(params);
+        // check for no network
+        if (this.$.financial.lastRequest && this.$.financial.lastRequest.status === 0) {
+          this._handleNoNetwork();
+        } else {
+          this._log(params);
 
-        this.fire("rise-financial-error", resp);
-        this._startTimer();
+          // delete cached data
+          this.$.data.deleteItem(this._getDataCacheKey());
+
+          this.fire("rise-financial-error", resp);
+          this._startTimer();
+        }
       }
     }, {
       key: "_getSymbols",
@@ -299,7 +322,7 @@ var financialVersion = "1.0.1";
     }, {
       key: "ready",
       value: function ready() {
-        var _this2 = this;
+        var _this3 = this;
 
         var params = {
           event: "ready"
@@ -311,12 +334,12 @@ var financialVersion = "1.0.1";
 
         // listen for data ping received
         this.$.data.addEventListener("rise-data-ping-received", function (e) {
-          _this2._onDataPingReceived(e.detail);
+          _this3._onDataPingReceived(e.detail);
         });
 
         // listen for logger display id received
         this.$.logger.addEventListener("rise-logger-display-id", function (e) {
-          _this2._onDisplayIdReceived(e.detail);
+          _this3._onDisplayIdReceived(e.detail);
         });
 
         this._log(params);

--- a/rise-financial.js
+++ b/rise-financial.js
@@ -268,6 +268,8 @@ var financialVersion = "1.0.1";
           response.data = resp.table;
         }
 
+        this.$.data.saveItem(this._getDataCacheKey(), response);
+
         this.fire("rise-financial-response", response);
         this._startTimer();
       }

--- a/test/unit/rise-financial.html
+++ b/test/unit/rise-financial.html
@@ -355,6 +355,50 @@
 
     } );
 
+    suite( "_handleNoNetwork", () => {
+
+      test( "should fire rise-google-sheet-response when cached data exists", ( done ) => {
+        let listener = ( response ) => {
+          assert.deepEqual( response.detail, {
+            instruments: instruments,
+            data: realTimeData.table,
+          } );
+
+          financialRequest.removeEventListener( "rise-financial-response", listener );
+          financialRequest.$.data.getItem.restore();
+
+          done();
+        };
+
+        sinon.stub( financialRequest.$.data, "getItem", ( key, cb ) => {
+          return cb( {
+            instruments: instruments,
+            data: realTimeData.table,
+          } );
+        } );
+
+        financialRequest.addEventListener( "rise-financial-response", listener );
+        financialRequest._handleNoNetwork();
+      } );
+
+      test( "should fire rise-financial-no-network when cached data doesn't exist", ( done ) => {
+        let listener = () => {
+          financialRequest.removeEventListener( "rise-financial-no-network", listener );
+          financialRequest.$.data.getItem.restore();
+
+          done();
+        };
+
+        sinon.stub( financialRequest.$.data, "getItem", ( key, cb ) => {
+          return cb( null );
+        } );
+
+        financialRequest.addEventListener( "rise-financial-no-network", listener );
+        financialRequest._handleNoNetwork();
+      } );
+
+    } );
+
     suite( "_handleData", () => {
       const e = { stopPropagation: () => {} };
 

--- a/test/unit/rise-financial.html
+++ b/test/unit/rise-financial.html
@@ -66,6 +66,10 @@
       clock.restore();
     } );
 
+    setup( () => {
+      localStorage.removeItem( `risefinancial_${financialRequest.type}_${financialRequest.displayId}_${financialRequest.financialList}` );
+    } );
+
     suite( "Properties", () => {
 
       test( "should set financial list property", () => {
@@ -389,6 +393,20 @@
 
         financialRequest.addEventListener( "rise-financial-response", listener );
         financialRequest._handleData( e, {} );
+      } );
+
+      test( "should cache the data that gets provided in 'rise-financial-response' event", () => {
+        let spy = sinon.spy( financialRequest.$.data, "saveItem" );
+
+        financialRequest._handleData( e, realTimeData );
+
+        assert.equal( spy.args[ 0 ][ 0 ], financialRequest._getDataCacheKey() );
+        assert.deepEqual( spy.args[ 0 ][ 1 ], {
+          instruments: instruments,
+          data: realTimeData.table,
+        } );
+
+        spy.restore();
       } );
 
     } );

--- a/test/unit/rise-financial.html
+++ b/test/unit/rise-financial.html
@@ -121,13 +121,18 @@
 
     suite( "_startTimer", () => {
 
+      teardown( () => {
+        financialRequest._refreshPending = false;
+      } );
+
       test( "should make a new request for data after 1 minute", () => {
-        const stub = sinon.stub( financialRequest.$.financial, "generateRequest" );
+        const stub = sinon.stub( financialRequest, "go" );
 
         financialRequest._startTimer();
         clock.tick( 60000 );
 
-        assert.isTrue( stub.calledOnce );
+        assert.isTrue( stub.calledOnce, "go() called once" );
+        assert.isTrue( financialRequest._refreshPending, "_refreshPending value is true" );
 
         stub.restore();
       } );
@@ -557,6 +562,7 @@
         financialRequest._setDisplayId( "preview" );
         financialRequest._displayIdReceived = true;
         financialRequest._goPending = false;
+        financialRequest._initialGo = true;
       } );
 
       test( "should flag that a go() is pending if display ID has not been received", () => {
@@ -586,7 +592,7 @@
         assert.isTrue( financialRequest._goPending );
       } );
 
-      test( "should call _getData() if display ID, instruments, and data ping have been received", () => {
+      test( "should call _getData() when this is the initial go() call", () => {
         const spy = sinon.spy( financialRequest, "_getData" );
 
         financialRequest._displayIdReceived = true;
@@ -594,10 +600,85 @@
         financialRequest._dataPingReceived = true;
         financialRequest.go();
 
-        assert.isFalse( financialRequest._goPending );
-        assert.isTrue( spy.calledOnce );
+        assert.isFalse( financialRequest._goPending, "_goPending set to false" );
+        assert.isTrue( spy.calledOnce, "_getData is called" );
+        assert.isFalse( financialRequest._initialGo, "_initialGo set to false" );
 
         spy.restore();
+      } );
+
+      test( "should execute request when not initial go() call and no cached data available", () => {
+        let requestStub = sinon.stub( financialRequest.$.financial, "generateRequest" );
+
+        sinon.stub( financialRequest.$.data, "getItem", ( key, cb ) => {
+          return cb( null );
+        } );
+
+        financialRequest._displayIdReceived = true;
+        financialRequest._instrumentsReceived = true;
+        financialRequest._dataPingReceived = true;
+        financialRequest._initialGo = false;
+
+        financialRequest.go();
+
+        assert.isTrue( requestStub.calledOnce, "request executed" );
+
+        financialRequest.$.data.getItem.restore();
+        financialRequest.$.financial.generateRequest.restore();
+      } );
+
+      test( "should execute request when not initial go() call and refresh is pending", () => {
+        let requestStub = sinon.stub( financialRequest.$.financial, "generateRequest" );
+
+        sinon.stub( financialRequest.$.data, "getItem", ( key, cb ) => {
+          return cb( {
+            instruments: instruments,
+            data: realTimeData.table,
+          } );
+        } );
+
+        financialRequest._displayIdReceived = true;
+        financialRequest._instrumentsReceived = true;
+        financialRequest._dataPingReceived = true;
+        financialRequest._initialGo = false;
+        financialRequest._refreshPending = true;
+
+        financialRequest.go();
+
+        assert.isTrue( requestStub.calledOnce, "request executed" );
+        assert.isFalse( financialRequest._refreshPending, "_refreshPending set to false" );
+
+        financialRequest.$.data.getItem.restore();
+        financialRequest.$.financial.generateRequest.restore();
+      } );
+
+      test( "should fire 'rise-financial-response' with cached data", ( done ) => {
+        const listener = ( response ) => {
+          assert.deepEqual( response.detail, {
+            instruments: instruments,
+            data: realTimeData.table,
+          } );
+
+          financialRequest.removeEventListener( "rise-financial-response", listener );
+          financialRequest.$.data.getItem.restore();
+
+          done();
+        };
+
+        sinon.stub( financialRequest.$.data, "getItem", ( key, cb ) => {
+          return cb( {
+            instruments: instruments,
+            data: realTimeData.table,
+          } );
+        } );
+
+        financialRequest._displayIdReceived = true;
+        financialRequest._instrumentsReceived = true;
+        financialRequest._dataPingReceived = true;
+        financialRequest._initialGo = false;
+        financialRequest._refreshPending = false;
+        financialRequest.addEventListener( "rise-financial-response", listener );
+        financialRequest.go();
       } );
 
     } );

--- a/test/unit/rise-financial.html
+++ b/test/unit/rise-financial.html
@@ -386,9 +386,9 @@
         financialRequest._handleNoNetwork();
       } );
 
-      test( "should fire rise-financial-no-network when cached data doesn't exist", ( done ) => {
+      test( "should fire rise-financial-no-data when cached data doesn't exist", ( done ) => {
         let listener = () => {
-          financialRequest.removeEventListener( "rise-financial-no-network", listener );
+          financialRequest.removeEventListener( "rise-financial-no-data", listener );
           financialRequest.$.data.getItem.restore();
 
           done();
@@ -398,7 +398,7 @@
           return cb( null );
         } );
 
-        financialRequest.addEventListener( "rise-financial-no-network", listener );
+        financialRequest.addEventListener( "rise-financial-no-data", listener );
         financialRequest._handleNoNetwork();
       } );
 

--- a/test/unit/rise-financial.html
+++ b/test/unit/rise-financial.html
@@ -362,7 +362,7 @@
 
     suite( "_handleNoNetwork", () => {
 
-      test( "should fire rise-google-sheet-response when cached data exists", ( done ) => {
+      test( "should fire rise-financial-response when cached data exists", ( done ) => {
         let listener = ( response ) => {
           assert.deepEqual( response.detail, {
             instruments: instruments,

--- a/test/unit/rise-financial.html
+++ b/test/unit/rise-financial.html
@@ -183,6 +183,14 @@
       } );
     } );
 
+    suite( "_getDataCacheKey", () => {
+
+      test( "should return correct data cache key", () => {
+        assert.equal( financialRequest._getDataCacheKey(), "risefinancial_realtime_preview_Stocks" );
+      } );
+
+    } );
+
     suite( "_getInstruments", () => {
       let spy;
 

--- a/test/unit/rise-financial.html
+++ b/test/unit/rise-financial.html
@@ -118,14 +118,14 @@
     suite( "_startTimer", () => {
 
       test( "should make a new request for data after 1 minute", () => {
-        const spy = sinon.spy( financialRequest.$.financial, "generateRequest" );
+        const stub = sinon.stub( financialRequest.$.financial, "generateRequest" );
 
         financialRequest._startTimer();
         clock.tick( 60000 );
 
-        assert( spy.calledOnce );
+        assert.isTrue( stub.calledOnce );
 
-        spy.restore();
+        stub.restore();
       } );
 
     } );
@@ -492,6 +492,7 @@
       test( "should flag that a go() is pending if display ID has not been received", () => {
         financialRequest._displayIdReceived = false;
         financialRequest._instrumentsReceived = true;
+        financialRequest._dataPingReceived = true;
         financialRequest.go();
 
         assert.isTrue( financialRequest._goPending );
@@ -500,16 +501,27 @@
       test( "should flag that a go() is pending if instruments have not been received", () => {
         financialRequest._displayIdReceived = true;
         financialRequest._instrumentsReceived = false;
+        financialRequest._dataPingReceived = true;
         financialRequest.go();
 
         assert.isTrue( financialRequest._goPending );
       } );
 
-      test( "should call _getData() if display ID and instruments have been received", () => {
+      test( "should flag that a go() is pending if data ping has not been received", () => {
+        financialRequest._displayIdReceived = true;
+        financialRequest._instrumentsReceived = true;
+        financialRequest._dataPingReceived = false;
+        financialRequest.go();
+
+        assert.isTrue( financialRequest._goPending );
+      } );
+
+      test( "should call _getData() if display ID, instruments, and data ping have been received", () => {
         const spy = sinon.spy( financialRequest, "_getData" );
 
         financialRequest._displayIdReceived = true;
         financialRequest._instrumentsReceived = true;
+        financialRequest._dataPingReceived = true;
         financialRequest.go();
 
         assert.isFalse( financialRequest._goPending );


### PR DESCRIPTION
- Using `rise-data` component for cache management
- Caches data to Rise Cache when handling a data response from financial request
- Conditionally makes new financial request upon `go()` call if a refresh is pending or no cached data is available, otherwise fires "rise-financial-response" event providing cached data
- When handling error, checks `lastRequest` of `<byutv-jsonp>` instance for a possible `status` of 0 in order to handle no network, if so, fires "rise-financial-no-network" event if no cached data available
- When handling error, if no request status available or status is not 0, fires "rise-financial-error" and deletes any cached data
- Feature version bump