### PR TITLE
Update rise-logger version to 1.0.3

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-financial",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "authors": [
     "Rise Vision"
   ],
@@ -23,13 +23,13 @@
     "iron-ajax": "PolymerElements/iron-ajax#^1.0.0",
     "polymer": "Polymer/polymer#^1.0.0",
     "rise-data": "https://github.com/Rise-Vision/rise-data.git#1.1.0",
-    "rise-logger": "https://github.com/Rise-Vision/rise-logger.git#1.0.2"
+    "rise-logger": "https://github.com/Rise-Vision/rise-logger.git#1.0.3"
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
     "web-component-tester": "*"
   },
   "resolutions": {
-    "rise-logger": "1.0.2"
+    "rise-logger": "1.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-financial",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Rise Vision web component for managing financial data",
   "scripts": {
     "test": "gulp test",

--- a/rise-financial.js
+++ b/rise-financial.js
@@ -19,7 +19,7 @@ var config = {
   }
 };
 
-var financialVersion = "1.1.0";
+var financialVersion = "1.1.1";
 (function financial() {
   /* global Polymer, financialVersion, firebase, config */
 


### PR DESCRIPTION
- Updating to 1.0.3 of `rise-logger` for a bug fix regarding logging queued items
- Minor patch version bump