### PR TITLE
Revised handling of request error

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,6 @@ Next, construct your HTML page. You should include `webcomponents-lite.min.js` b
         financial.addEventListener( "rise-financial-response", ( e ) => {
           console.log( e.detail );
         } );
-
-        financial.addEventListener( "rise-financial-error", ( e ) => {
-          console.log( e.detail );
-        } );
         
         financial.addEventListener( "rise-financial-no-data", ( e ) => {
           console.log( "No data available" );

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-financial",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "authors": [
     "Rise Vision"
   ],

--- a/demo/index.html
+++ b/demo/index.html
@@ -9,7 +9,7 @@
   <link rel="import" href="../rise-financial.html">
 </head>
 <body unresolved>
-  <rise-financial financial-list="preview" instrument-fields='["instrument", "name", "lastPrice", "netChange"]'></rise-financial>
+  <rise-financial financial-list="-KZg7EhXONx26-LVLg5T" instrument-fields='["instrument", "name", "lastPrice", "netChange"]'></rise-financial>
 
   <script>
     const financial = document.querySelector( "rise-financial" );
@@ -18,12 +18,8 @@
       console.log( e.detail );
     } );
 
-    financial.addEventListener( "rise-financial-error", ( e ) => {
-      console.log( e.detail );
-    } );
-
     financial.addEventListener( "rise-financial-no-data", () => {
-      console.log( "No cached data available and no network" );
+      console.log( "No data available" );
     } );
 
     financial.go();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-financial",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Rise Vision web component for managing financial data",
   "scripts": {
     "test": "gulp test",

--- a/rise-financial.js
+++ b/rise-financial.js
@@ -19,7 +19,7 @@ var config = {
   }
 };
 
-var financialVersion = "1.1.1";
+var financialVersion = "1.2.0";
 (function financial() {
   /* global Polymer, financialVersion, firebase, config */
 

--- a/rise-financial.js
+++ b/rise-financial.js
@@ -44,9 +44,9 @@ var financialVersion = "1.1.1";
          */
 
         /**
-        * Fired when an error is received.
+        * Fired when an error occurs and no cached data is available.
         *
-        * @event rise-financial-error
+        * @event rise-financial-no-data
         */
 
         this.properties = {
@@ -261,21 +261,6 @@ var financialVersion = "1.1.1";
         financial.params = params;
       }
     }, {
-      key: "_handleNoNetwork",
-      value: function _handleNoNetwork() {
-        var _this2 = this;
-
-        this.$.data.getItem(this._getDataCacheKey(), function (cachedData) {
-          if (cachedData) {
-            _this2.fire("rise-financial-response", cachedData);
-          } else {
-            _this2.fire("rise-financial-no-data");
-          }
-        });
-
-        this._startTimer();
-      }
-    }, {
       key: "_handleData",
       value: function _handleData(e, resp) {
         var response = {
@@ -293,25 +278,26 @@ var financialVersion = "1.1.1";
       }
     }, {
       key: "_handleError",
-      value: function _handleError(e, resp) {
-        // error response provides no request or error objects, use instruments to provide some detail instead
+      value: function _handleError() {
+        var _this2 = this;
+
+        // error response provides no request or error message, use instruments to provide some detail instead
         var params = {
           event: "error",
           event_details: "Instrument List: " + JSON.stringify(this._instruments)
         };
 
-        // check for no network
-        if (this.$.financial.lastRequest && this.$.financial.lastRequest.status === 0) {
-          this._handleNoNetwork();
-        } else {
-          this._log(params);
+        this._log(params);
 
-          // delete cached data
-          this.$.data.deleteItem(this._getDataCacheKey());
+        this.$.data.getItem(this._getDataCacheKey(), function (cachedData) {
+          if (cachedData) {
+            _this2.fire("rise-financial-response", cachedData);
+          } else {
+            _this2.fire("rise-financial-no-data");
+          }
+        });
 
-          this.fire("rise-financial-error", resp);
-          this._startTimer();
-        }
+        this._startTimer();
       }
     }, {
       key: "_getSymbols",

--- a/test/unit/rise-financial.html
+++ b/test/unit/rise-financial.html
@@ -360,50 +360,6 @@
 
     } );
 
-    suite( "_handleNoNetwork", () => {
-
-      test( "should fire rise-financial-response when cached data exists", ( done ) => {
-        let listener = ( response ) => {
-          assert.deepEqual( response.detail, {
-            instruments: instruments,
-            data: realTimeData.table,
-          } );
-
-          financialRequest.removeEventListener( "rise-financial-response", listener );
-          financialRequest.$.data.getItem.restore();
-
-          done();
-        };
-
-        sinon.stub( financialRequest.$.data, "getItem", ( key, cb ) => {
-          return cb( {
-            instruments: instruments,
-            data: realTimeData.table,
-          } );
-        } );
-
-        financialRequest.addEventListener( "rise-financial-response", listener );
-        financialRequest._handleNoNetwork();
-      } );
-
-      test( "should fire rise-financial-no-data when cached data doesn't exist", ( done ) => {
-        let listener = () => {
-          financialRequest.removeEventListener( "rise-financial-no-data", listener );
-          financialRequest.$.data.getItem.restore();
-
-          done();
-        };
-
-        sinon.stub( financialRequest.$.data, "getItem", ( key, cb ) => {
-          return cb( null );
-        } );
-
-        financialRequest.addEventListener( "rise-financial-no-data", listener );
-        financialRequest._handleNoNetwork();
-      } );
-
-    } );
-
     suite( "_handleData", () => {
       const e = { stopPropagation: () => {} };
 
@@ -471,35 +427,48 @@
         logStub.restore();
       } );
 
-      test( "should fire rise-financial-error", ( done ) => {
-        const resp =
-          {
-            "request": {
-              "status": 404,
-              "statusText": "An error occurred"
-            }
-          },
-          listener = ( response ) => {
-            assert.deepEqual( response.detail, resp );
+      test( "should fire rise-financial-response when cached data exists", ( done ) => {
+        let listener = ( response ) => {
+          assert.deepEqual( response.detail, {
+            instruments: instruments,
+            data: realTimeData.table,
+          } );
 
-            financialRequest.removeEventListener( "rise-financial-error", listener );
-            done();
-          };
+          financialRequest.removeEventListener( "rise-financial-response", listener );
+          financialRequest.$.data.getItem.restore();
 
-        financialRequest.addEventListener( "rise-financial-error", listener );
-        financialRequest._handleError( {}, resp );
+          done();
+        };
+
+        sinon.stub( financialRequest.$.data, "getItem", ( key, cb ) => {
+          return cb( {
+            instruments: instruments,
+            data: realTimeData.table,
+          } );
+        } );
+
+        financialRequest.addEventListener( "rise-financial-response", listener );
+        financialRequest._handleError();
+      } );
+
+      test( "should fire rise-financial-no-data when cached data doesn't exist", ( done ) => {
+        let listener = () => {
+          financialRequest.removeEventListener( "rise-financial-no-data", listener );
+          financialRequest.$.data.getItem.restore();
+
+          done();
+        };
+
+        sinon.stub( financialRequest.$.data, "getItem", ( key, cb ) => {
+          return cb( null );
+        } );
+
+        financialRequest.addEventListener( "rise-financial-no-data", listener );
+        financialRequest._handleError();
       } );
 
       test( "should call _log() with correct params", () => {
-        const resp =
-          {
-            "request": {
-              "status": 404,
-              "statusText": "An error occurred"
-            }
-          };
-
-        financialRequest._handleError( {}, resp );
+        financialRequest._handleError();
 
         assert.isTrue( logStub.calledWith( {
           event: "error",


### PR DESCRIPTION
- Removed logic for determining no network based on `status` value from financial server error response, it's never provided
- `_handleError` now provides cached data in "rise-financial-response" event if cached data exists, otherwise fires "rise-financial-no-data" event
- Unit tests revised
- Updated demo event handling and providing production financial list id
- Updated README to remove deprecated event handler
- Version bump