### PR TITLE
Update demo to prompt entry for financial list id

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-financial",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "authors": [
     "Rise Vision"
   ],

--- a/demo/index.html
+++ b/demo/index.html
@@ -9,10 +9,28 @@
   <link rel="import" href="../rise-financial.html">
 </head>
 <body unresolved>
-  <rise-financial financial-list="-KZg7EhXONx26-LVLg5T" instrument-fields='["instrument", "name", "lastPrice", "netChange"]'></rise-financial>
+  <p>An example of <code>&lt;rise-financial&gt;</code>:</p>
+
+  <p>Enter your Financial List ID and click "Submit"</p>
+
+  <form style="margin-bottom: 10px">
+    <input type="text" style="width: 300px;" name="list-id" id="list-id" maxlength="100">
+    <input type="button" name="goBtn" value="Submit" />
+  </form>
+
+  <rise-financial instrument-fields='["instrument", "name", "lastPrice", "netChange"]'></rise-financial>
 
   <script>
-    const financial = document.querySelector( "rise-financial" );
+    const financial = document.querySelector( "rise-financial" ),
+      goBtn = document.querySelector("input[name='goBtn']"),
+      listIdInput = document.querySelector("input[name='list-id']");
+
+    goBtn.addEventListener("click", function() {
+      if (listIdInput.value !== "") {
+        financial.setAttribute("financial-list", listIdInput.value);
+        financial.go();
+      }
+    });
 
     financial.addEventListener( "rise-financial-response", ( e ) => {
       console.log( e.detail );
@@ -22,7 +40,7 @@
       console.log( "No data available" );
     } );
 
-    financial.go();
+
   </script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-financial",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Rise Vision web component for managing financial data",
   "scripts": {
     "test": "gulp test",

--- a/rise-financial-es6.js
+++ b/rise-financial-es6.js
@@ -53,7 +53,8 @@
          */
         financialList: {
           type: String,
-          value: ""
+          value: "",
+          observer: "_financialListChanged"
         },
 
         /**
@@ -280,6 +281,19 @@
       } );
 
       this._log( params );
+    }
+
+    _financialListChanged() {
+      // ensure a go() call gets made when instruments handled via _handleInstruments()
+      this._goPending = true;
+
+      if ( !this._initialGo ) {
+        this.cancelDebouncer( "refresh" );
+        // make sure cached data isn't provided
+        this._refreshPending = true;
+      }
+
+      this._getInstruments();
     }
 
     attached() {

--- a/rise-financial.js
+++ b/rise-financial.js
@@ -19,7 +19,7 @@ var config = {
   }
 };
 
-var financialVersion = "1.2.0";
+var financialVersion = "1.2.1";
 (function financial() {
   /* global Polymer, financialVersion, firebase, config */
 

--- a/rise-financial.js
+++ b/rise-financial.js
@@ -80,7 +80,8 @@ var financialVersion = "1.2.0";
            */
           financialList: {
             type: String,
-            value: ""
+            value: "",
+            observer: "_financialListChanged"
           },
 
           /**
@@ -332,6 +333,20 @@ var financialVersion = "1.2.0";
         });
 
         this._log(params);
+      }
+    }, {
+      key: "_financialListChanged",
+      value: function _financialListChanged() {
+        // ensure a go() call gets made when instruments handled via _handleInstruments()
+        this._goPending = true;
+
+        if (!this._initialGo) {
+          this.cancelDebouncer("refresh");
+          // make sure cached data isn't provided
+          this._refreshPending = true;
+        }
+
+        this._getInstruments();
       }
     }, {
       key: "attached",

--- a/test/integration/rise-financial-realtime.html
+++ b/test/integration/rise-financial-realtime.html
@@ -57,6 +57,18 @@
 
     } );
 
+    suite( "financial list id change", () => {
+
+      test( "should call _financialListChanged()", () => {
+        let changedStub = sinon.stub( financialRequest, "_financialListChanged" );
+
+        financialRequest.setAttribute( "financial-list", "abc123" );
+        assert.isTrue( changedStub.calledOnce );
+        changedStub.restore();
+      } );
+
+    } );
+
   } );
 </script>
 </body>

--- a/test/unit/rise-financial.html
+++ b/test/unit/rise-financial.html
@@ -490,6 +490,49 @@
 
     } );
 
+    suite( "_financialListChanged", () => {
+      let instrumentsStub;
+
+      setup( () => {
+        instrumentsStub = sinon.stub( financialRequest, "_getInstruments" );
+      } );
+
+      teardown( () => {
+        financialRequest._goPending = false;
+        financialRequest._refreshPending = false;
+        financialRequest._initialGo = true;
+        instrumentsStub.restore();
+      } );
+
+      test( "should flag that a go() call is pending", () => {
+        financialRequest._goPending = false;
+        financialRequest._financialListChanged();
+
+        assert.isTrue( financialRequest._goPending );
+      } );
+
+      test( "should cancel refresh timer and flag refresh is pending if go() call has executed before", () => {
+        let cancelStub = sinon.stub( financialRequest, "cancelDebouncer" );
+
+        financialRequest._refreshPending = false;
+        financialRequest._initialGo = false;
+
+        financialRequest._financialListChanged();
+
+        assert.isTrue( cancelStub.calledOnce );
+        assert.isTrue( financialRequest._refreshPending );
+
+        cancelStub.restore();
+      } );
+
+      test( "should call _getInstruments()", () => {
+        financialRequest._financialListChanged();
+
+        assert.isTrue( instrumentsStub.calledOnce );
+      } );
+
+    } );
+
     suite( "ready", () => {
       let logStub;
 


### PR DESCRIPTION
- Observing `financialList` property for changes
- Handling change to `financialList` property by getting instruments for financial list and ensuring a new request for data occurs
- Demo now prompts for a user to enter a financial list id to submit
- Unit and integration tests added
- Version bump