### PR TITLE
Use relative protocols for financial server urls

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-financial",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "authors": [
     "Rise Vision"
   ],

--- a/config/prod.js
+++ b/config/prod.js
@@ -8,7 +8,7 @@ const config = {
     databaseURL: "https://fir-b3915.firebaseio.com",
   },
   financial: {
-    realTimeURL: "http://contentfinancial2.appspot.com/data",
-    historicalURL: "http://contentfinancial2.appspot.com/data/historical",
+    realTimeURL: "//contentfinancial2.appspot.com/data",
+    historicalURL: "//contentfinancial2.appspot.com/data/historical",
   }
 };

--- a/config/test.js
+++ b/config/test.js
@@ -8,7 +8,7 @@ const config = {
     databaseURL: "https://fir-stage.firebaseio.com",
   },
   financial: {
-    realTimeURL: "http://contentfinancial2-test.appspot.com/data",
-    historicalURL: "http://contentfinancial2-test.appspot.com/data/historical",
+    realTimeURL: "//contentfinancial2-test.appspot.com/data",
+    historicalURL: "//contentfinancial2-test.appspot.com/data/historical",
   }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-financial",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Rise Vision web component for managing financial data",
   "scripts": {
     "test": "cross-env NODE_ENV=test gulp test",

--- a/rise-financial.js
+++ b/rise-financial.js
@@ -14,12 +14,12 @@ var config = {
     databaseURL: "https://fir-b3915.firebaseio.com"
   },
   financial: {
-    realTimeURL: "http://contentfinancial2.appspot.com/data",
-    historicalURL: "http://contentfinancial2.appspot.com/data/historical"
+    realTimeURL: "//contentfinancial2.appspot.com/data",
+    historicalURL: "//contentfinancial2.appspot.com/data/historical"
   }
 };
 
-var financialVersion = "1.2.3";
+var financialVersion = "1.2.4";
 (function financial() {
   /* global Polymer, financialVersion, firebase, config */
 

--- a/test/unit/rise-financial-historical.html
+++ b/test/unit/rise-financial-historical.html
@@ -80,7 +80,7 @@
       test( "should set 'url' attribute of JSONP component", () => {
         financialRequest._getData( props, instrument, [] );
 
-        assert.equal( financial.url, "http://contentfinancial2-test.appspot.com/data/historical" );
+        assert.equal( financial.url, "//contentfinancial2-test.appspot.com/data/historical" );
       } );
 
       test( "should set 'params' attribute of JSONP component", () => {

--- a/test/unit/rise-financial.html
+++ b/test/unit/rise-financial.html
@@ -327,7 +327,7 @@
       test( "should set 'url' attribute of JSONP component", () => {
         financialRequest._getData( props, instruments, [] );
 
-        assert.equal( financial.url, "http://contentfinancial2-test.appspot.com/data" );
+        assert.equal( financial.url, "//contentfinancial2-test.appspot.com/data" );
       } );
 
       test( "should set 'params' attribute of JSONP component for single instrument", () => {


### PR DESCRIPTION
- Rely on whatever protocol the current page was loaded with for financial server URLs
- Unit tests revised
- Version bump