### PR TITLE
Refactor handling connected status

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-financial",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "authors": [
     "Rise Vision"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-financial",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "description": "Rise Vision web component for managing financial data",
   "scripts": {
     "test": "cross-env NODE_ENV=test gulp test",

--- a/test/unit/rise-financial.html
+++ b/test/unit/rise-financial.html
@@ -734,7 +734,7 @@
 
     } );
 
-    suite( "attached", () => {
+    suite( "_handleConnected", () => {
       let stub;
 
       setup( () => {
@@ -756,9 +756,19 @@
       } );
 
       test( "should not call '_getInstruments()' if instruments already received", () => {
-        setFirebaseConnectionStatus( false );
+        setFirebaseConnectionStatus( true );
 
         assert.equal( stub.callCount, 0 );
+        assert.isTrue( financialRequest._firebaseConnected );
+      } );
+
+      test( "should call '_getInstruments()' if no connection within 2 seconds and still needing instruments", () => {
+        financialRequest._instrumentsReceived = false;
+        setFirebaseConnectionStatus( false );
+
+        clock.tick( 2000 );
+
+        assert.isTrue( stub.calledOnce );
         assert.isFalse( financialRequest._firebaseConnected );
 
         financialRequest._firebaseConnected = true;


### PR DESCRIPTION
Firebase ".info/connected" returns false multiple times before returning true when network online. Accounting for this by setting a 2 second timer to allow for finalized status before calling `_getInstruments()`